### PR TITLE
batteryservice: Remove remnants of CAF's HVDCP changes

### DIFF
--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -58,10 +58,6 @@ import android.util.Slog;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 
@@ -1054,33 +1050,6 @@ public final class BatteryService extends SystemService {
             // in the alpha channel of the color and let the HAL sort it out.
             mUseSegmentedBatteryLed = context.getResources().getBoolean(
                     org.cyanogenmod.platform.internal.R.bool.config_useSegmentedBatteryLed);
-        }
-
-        private boolean isHvdcpPresent() {
-            File mChargerTypeFile = new File("/sys/class/power_supply/usb/type");
-            FileReader fileReader;
-            BufferedReader br;
-            String type;
-            boolean ret = false;
-
-            if (!mChargerTypeFile.exists()) {
-                // Device does not support HVDCP
-                return ret;
-            }
-
-            try {
-                fileReader = new FileReader(mChargerTypeFile);
-                br = new BufferedReader(fileReader);
-                type =  br.readLine();
-                if (type.regionMatches(true, 0, "USB_HVDCP", 0, 9))
-                    ret = true;
-                br.close();
-                fileReader.close();
-            } catch (IOException e) {
-                Slog.e(TAG, "Failure in reading charger type", e);
-            }
-
-            return ret;
         }
 
         /**


### PR DESCRIPTION
Commit ce521ee7de0bf1264abe0cd399f59e505ff28005 removed the usage
of isHvdcpPresent(), but did not remove the function itself.

Remove isHvdcpPresent() as clean-up.

This essentially reverts the rest of the following commits:
64deb448b8ac50587bc90e3506e639e4e1a066ed batteryservice: Avoid exception if device doesn't support HVDCP
4df4f532741d4aaa848d70c2465765a9a8b19d87 batteryservice: add support for charger led blinking

Change-Id: Ie39c11ee9811f6af84a55ed85b72123cc449c735