### PR TITLE
Make Power Notification Controls scrollable

### DIFF
--- a/packages/SystemUI/res/layout/power_notification_controls_settings.xml
+++ b/packages/SystemUI/res/layout/power_notification_controls_settings.xml
@@ -21,10 +21,16 @@
 
     <include layout="@layout/switch_bar" />
 
-    <TextView
+    <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:text="@string/cm_power_notification_controls_description"/>
+            android:layout_height="wrap_content">
+
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:text="@string/cm_power_notification_controls_description"/>
+
+    </ScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
The textview is too long for most devices and gets cut off.

Change-Id: I3e76d4a904554a1fc4a50d594601b2b147960bba