### PR TITLE
usb: ensure accessory detached sent on re-attach

### DIFF
--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
@@ -586,7 +586,13 @@ public class UsbDeviceManager {
 
             if (mConfigured && enteringAccessoryMode) {
                 // successfully entered accessory mode
-
+                if (mCurrentAccessory != null) {
+                    Slog.w(TAG, "USB accessory re-attached, detach was not announced!");
+                    if (mBootCompleted) {
+                        getCurrentSettings().accessoryDetached(mCurrentAccessory);
+                    }
+                    mCurrentAccessory = null;
+                }
                 if (mAccessoryStrings != null) {
                     mCurrentAccessory = new UsbAccessory(mAccessoryStrings);
                     Slog.d(TAG, "entering USB accessory mode: " + mCurrentAccessory);


### PR DESCRIPTION
It's possible for USB state change events to get swallowed if the
cable is reconnected quickly because state changes are de-bounced with
a 1 second interval.

As a result an accessory detached event will not be sent if it
re-attaches quickly. However, UsbDeviceManager will send an attached
event when the USB connection is configured. This causes apps to
misbehave and attempt to open the accessory without closing the
previous one.

The call to openAccessory fails (with EBUSY) because the underlying
/dev/usb_accessory chardev is already open exclusively by the first
accessory.

Fix this issue by sending a detached event before sending an attached
event if the previous accessory was not cleaned up properly.

This change fixes a failure in CTSVerifier's USB Accessory Test where
the test fails if you reconnect the USB cable quickly.

OPO-688, FEIJ-471

Change-Id: I49690553213e866d200da1fb22c83348c6eb3491