### PR TITLE
core: cm_symbols: Remove deprecated <private-symbols>

### DIFF
--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -16,10 +16,6 @@
      limitations under the License.
 -->
 <resources>
-    <!-- We don't want to publish private symbols in android.R as part of the
-         SDK.  Instead, put them here. -->
-    <private-symbols package="com.android.internal" />
-
     <!-- Notification and battery light -->
     <java-symbol type="bool" name="config_intrusiveNotificationLed" />
     <java-symbol type="bool" name="config_intrusiveBatteryLed" />


### PR DESCRIPTION
This has been replaced by the command line flag --private-symbols
as of commit 535fea1e42b16c8b4a681cc0101f79c3662cb8b3.

Change-Id: Ia927fd82119e9653013e87d2eeeb98a94145e035