### PR TITLE
Add wakelock option for flashlight

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5117,6 +5117,14 @@ public final class Settings {
         public static final String LOCK_SCREEN_ALLOW_PRIVATE_NOTIFICATIONS =
                 "lock_screen_allow_private_notifications";
 
+
+        /**
+         * Separate password for encryption and the lockscreen.
+          * @hide
+         */
+        public static final String LOCK_SEPARATE_ENCRYPTION_PASSWORD =
+                "lock_separate_encryption_password";
+
         /**
          * When set by a user, allows notification remote input atop a securely locked screen
          * without having to unlock

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -286,4 +286,7 @@
 
     <bool name="config_show4gForIWlan">false</bool>
     <bool name="config_showSignalForIWlan">false</bool>
+
+    <!-- Allow the flashlight service to use wakelocks -->
+    <bool name="config_useWakelockForFlashlight">false</bool>
 </resources>

--- a/services/core/java/com/android/server/LockSettingsService.java
+++ b/services/core/java/com/android/server/LockSettingsService.java
@@ -1638,6 +1638,7 @@ public class LockSettingsService extends ILockSettings.Stub {
         Secure.LOCK_BIOMETRIC_WEAK_FLAGS,
         Secure.LOCK_PATTERN_VISIBLE,
         Secure.LOCK_PATTERN_TACTILE_FEEDBACK_ENABLED,
+        Secure.LOCK_SEPARATE_ENCRYPTION_PASSWORD,
         Secure.LOCK_PATTERN_SIZE,
         Secure.LOCK_DOTS_VISIBLE,
         Secure.LOCK_SHOW_ERROR_PATH,


### PR DESCRIPTION
On some legacy devices, the flashlight can't stay on when screen is off.
With this change, the flashlight can use wakelock. For obvious reasons,
this is turned off by default and needs to be enabled using the overlay.

Change-Id: Ia69309cf023430c9e90634a722be97ebbf6677ca